### PR TITLE
機能追加: 最初にFusionページを自動表示

### DIFF
--- a/exif_to_fusion.py
+++ b/exif_to_fusion.py
@@ -36,6 +36,9 @@ class ExifToFusion():
                                                      self.cameraPkg)
 
     def main(self):
+        # Fusionページを自動的に開く
+        self.OpenFusionPage()
+        
         ret: dict = self.ShowMainDialog()
         if ret is None:
             sys.exit()
@@ -108,6 +111,17 @@ class ExifToFusion():
 
             values = titleIns.GenerateFusionParameter(e)
             self.SetFusionParameter(fusionComp, titleIns, values)
+
+    def OpenFusionPage(self) -> None:
+        """Fusionページを開く
+        """
+        try:
+            # DaVinci Resolve 19でFusionページを開く
+            self.resolve.OpenPage("fusion")
+            print("Fusionページを開きました")
+        except Exception as e:
+            print(f"Fusionページの切り替えでエラーが発生しました: {e}")
+            # エラーが発生してもスクリプトは継続する
 
     def LoadModulesFromFolder(self, folder, pkgName) -> dict:
         """指定したフォルダのモジュールを取得する


### PR DESCRIPTION
スクリプト実行前にFusionページを自動的に開く機能を追加しました。

## 変更内容

- OpenFusionPage()メソッドを追加してresolve.OpenPage("fusion")でFusionページに切り替え
- main()メソッドの開始時にOpenFusionPage()を自動実行
- エラーハンドリングを追加してページ切り替えが失敗してもスクリプトが続行実行

## 関連issue

Closes #38

Generated with [Claude Code](https://claude.ai/code)